### PR TITLE
fix: Fix indent error

### DIFF
--- a/ui/base/main_window_base.py
+++ b/ui/base/main_window_base.py
@@ -2525,9 +2525,9 @@ class MainWindowBase(QMainWindow):
                 details=f"Locked {success} items"
                 )
                 
-                # Lock FadCrypt's own config files
-                print("🔒 Protecting FadCrypt config files...")
-                self.file_lock_manager.lock_fadcrypt_configs()
+            # Lock FadCrypt's own config files
+            print("🔒 Protecting FadCrypt config files...")
+            self.file_lock_manager.lock_fadcrypt_configs()
         
         # Update UI button state
         self.update_monitoring_button_state(True)


### PR DESCRIPTION
There are indentation error while running on windows so I fix them

(I ran it on macOS but I realized they would have caused errors on Windows as well.)

```
Traceback (most recent call last):
  File "/Users/.../lab/FadCrypt/FadCrypt.py", line 364, in <module>
    main()
    ~~~~^^
  File "/Users/.../lab/FadCrypt/FadCrypt.py", line 296, in main
    MainWindowClass = get_main_window_class(force_windows=mock_windows)
  File "/Users/.../lab/FadCrypt/FadCrypt.py", line 246, in get_main_window_class
    from ui.base.main_window_base import MainWindowBase
  File "/Users/.../lab/FadCrypt/ui/base/main_window_base.py", line 2529
    print("🔒 Protecting FadCrypt config files...")
IndentationError: unexpected indent
```